### PR TITLE
Fix cmd info

### DIFF
--- a/exec/file/file_move.go
+++ b/exec/file/file_move.go
@@ -62,11 +62,11 @@ func NewFileMoveActionSpec() spec.ExpActionCommandSpec {
 # Move the file /home/logs/nginx.log to /tmp
 blade create file move --filepath /home/logs/nginx.log --target /tmp
 
-# Force Move the file /home/logs/nginx.log to /temp
+# Force Move the file /home/logs/nginx.log to /tmp
 blade create file move --filepath /home/logs/nginx.log --target /tmp --force
 
-# Move the file /home/logs/nginx.log to /temp/ and automatically create directories that don't exist
-blade create file move --filepath /home/logs/nginx.log --target /temp --auto-create-dir
+# Move the file /home/logs/nginx.log to /tmp and automatically create directories that don't exist
+blade create file move --filepath /home/logs/nginx.log --target /tmp --auto-create-dir
 `,
 			ActionPrograms:   []string{MoveFileBin},
 			ActionCategories: []string{category.SystemFile},

--- a/exec/network/network_occupy.go
+++ b/exec/network/network_occupy.go
@@ -19,12 +19,13 @@ package network
 import (
 	"context"
 	"fmt"
-	"github.com/chaosblade-io/chaosblade-exec-os/exec"
-	"github.com/chaosblade-io/chaosblade-spec-go/log"
-	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"net/http"
 	osutil "os"
 	"strings"
+
+	"github.com/chaosblade-io/chaosblade-exec-os/exec"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
 )
@@ -56,14 +57,14 @@ func NewOccupyActionSpec() spec.ExpActionCommandSpec {
 					Desc:     "cgroup root path, default value /sys/fs/cgroup",
 					NoArgs:   false,
 					Required: false,
-					Default: "/sys/fs/cgroup",
+					Default:  "/sys/fs/cgroup",
 				},
 			},
 			ActionFlags:    []spec.ExpFlagSpec{},
 			ActionExecutor: &OccupyActionExecutor{},
 			ActionExample: `
 #Specify port 8080 occupancy
-blade c network occupy --port 8080 --force
+blade create network occupy --port 8080 --force
 
 # The machine accesses external 14.215.177.39 machine (ping www.baidu.com) 80 port packet loss rate 100%
 blade create network loss --percent 100 --interface eth0 --remote-port 80 --destination-ip 14.215.177.39`,
@@ -110,7 +111,7 @@ func (oae *OccupyActionExecutor) Exec(uid string, ctx context.Context, model *sp
 	}
 	port := model.ActionFlags["port"]
 	if port == "" {
-		log.Errorf(ctx,"port is nil")
+		log.Errorf(ctx, "port is nil")
 		return spec.ResponseFailWithFlags(spec.ParameterLess, "port")
 	}
 	if _, ok := spec.IsDestroy(ctx); ok {
@@ -153,7 +154,7 @@ func (oae *OccupyActionExecutor) start(port string, ctx context.Context) *spec.R
 }
 
 func (oae *OccupyActionExecutor) stop(port string, ctx context.Context) *spec.Response {
-	ctx = context.WithValue(ctx,"bin", OccupyNetworkBin)
+	ctx = context.WithValue(ctx, "bin", OccupyNetworkBin)
 	return exec.Destroy(ctx, oae.channel, "network occupy")
 }
 

--- a/exec/network/network_occupy.go
+++ b/exec/network/network_occupy.go
@@ -23,10 +23,10 @@ import (
 	osutil "os"
 	"strings"
 
-	"github.com/chaosblade-io/chaosblade-exec-os/exec"
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
+	"github.com/chaosblade-io/chaosblade-exec-os/exec"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
 )
 


### PR DESCRIPTION
Fix: Optimize cmd args info on chaosblade-exec-os 
1. optimize cmd argos info on disk : /temp -->/tmp
2. optimize cmd argos info on network occupy :  blade c --> blade create
